### PR TITLE
BUG: ensure fixture setup/teardown is done on each iteration

### DIFF
--- a/pytest_leaks/plugin.py
+++ b/pytest_leaks/plugin.py
@@ -120,12 +120,22 @@ class LeakChecker(object):
             doctest_original_globs = None
 
         def run_test():
+            hasrequest = hasattr(item, "_request")
+            if hasrequest and not item._request:
+                item._initrequest()
+
             when[0] = "setup"
             hook.pytest_runtest_setup(item=item)
             when[0] = "call"
             hook.pytest_runtest_call(item=item)
             when[0] = "teardown"
             hook.pytest_runtest_teardown(item=item, nextitem=nextitem)
+
+            if hasrequest:
+                # Ensure fixtures etc are reset properly
+                item._request = False
+                item.funcargs = None
+
             if doctest_original_globs is not None:
                 item.dtest.globs.update(doctest_original_globs)
 

--- a/tests/test_leaks.py
+++ b/tests/test_leaks.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 import sys
-import re
-import textwrap
-import subprocess
 
 import pytest
 
@@ -182,57 +179,58 @@ def test_doctest_failure(testdir):
     assert result.ret == 1
 
 
-def test_doctest_pass(tmpdir):
-    # XXX: This test fails if run with the `testdir` fixture,
-    # XXX: for some currently unknown reason (gh-12)
-    with open(str(tmpdir / "test_doctest.py"), "w") as f:
-        f.write(textwrap.dedent("""
-        class SomeClass(object):
-            '''
-            >>> SomeClass()
-            <...
-            '''
-        """))
+def test_doctest_pass(testdir):
+    test_code = """
+    class SomeClass(object):
+        '''
+        >>> SomeClass()
+        <...
+        '''
+    """
 
-    output = subprocess.check_output(
-        [sys.executable, '-mpytest', '-R', ':',
-         '--doctest-modules', '-v', 'test_doctest.py'],
-        cwd=str(tmpdir))
+    testdir.makepyfile(test_code)
 
-    assert re.search(b"test_doctest\\.SomeClass\\s*PASSED", output), output
+    # XXX: fails without subprocess (gh-12)
+    result = testdir.runpytest_subprocess(
+        '-R', ':', '--doctest-modules', '-v'
+    )
+
+    result.stdout.fnmatch_lines([
+        "*::test_doctest_pass.SomeClass PASSED*"
+    ])
 
 
-def test_fixture_setup_teardown(tmpdir):
-    # XXX: This test fails if run with the `testdir` fixture,
-    # XXX: for some currently unknown reason (gh-12)
-    with open(str(tmpdir / "test_sth.py"), "w") as f:
-        f.write(textwrap.dedent("""
-        import pytest
+def test_fixture_setup_teardown(testdir):
+    test_code = """
+    import pytest
 
-        global_state = False
-        global_count = 0
-        prev_global_count = -1
+    global_state = False
+    global_count = 0
+    prev_global_count = -1
 
-        @pytest.fixture
-        def myfixture():
-            global global_state, global_count
-            global_state = True
-            try:
-                yield
-            finally:
-                global_state = False
-                global_count += 1
+    @pytest.fixture
+    def myfixture():
+        global global_state, global_count
+        global_state = True
+        try:
+            yield
+        finally:
+            global_state = False
+            global_count += 1
 
-        def test_sth(myfixture):
-            global prev_global_count
-            assert global_state
-            assert global_count > prev_global_count
-            prev_global_count = global_count
-        """))
+    def test_sth(myfixture):
+        global prev_global_count
+        assert global_state
+        assert global_count > prev_global_count
+        prev_global_count = global_count
+    """
 
-    output = subprocess.check_output(
-        [sys.executable, '-mpytest', '-R', ':',
-         '--doctest-modules', '-v', 'test_sth.py'],
-        cwd=str(tmpdir))
+    testdir.makepyfile(test_code)
 
-    assert re.search(b"::test_sth\\s*PASSED", output), output
+    result = testdir.runpytest_subprocess(
+        '-R', ':', '-v'
+    )
+
+    result.stdout.fnmatch_lines([
+        "*::test_sth PASSED*"
+    ])


### PR DESCRIPTION
Some extra code has to be included to make it work correctly.

Also, rewrite the subprocess tests using testdir.pytest_subprocess,
which I missed earlier.

Closes: #7