### PR TITLE
MAINT: use setuptools-scm to manage package version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+/pytest_leaks/_version.py
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+  "setuptools>=40.0",
+  "setuptools-scm",
+  "wheel",
+]
+build-backend = "setuptools.build_meta"

--- a/pytest_leaks/__init__.py
+++ b/pytest_leaks/__init__.py
@@ -1,1 +1,5 @@
-__version__ = "0.3.1.dev0"
+try:
+    # _version.py is written by setuptools-scm
+    from ._version import __version__
+except ImportError:
+    __version__ = "unknown"

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ AUTHORS = [
 
 setup(
     name='pytest-leaks',
-    version='0.3.1.dev0',
+    use_scm_version={"write_to": "pytest_leaks/_version.py"},
     author=", ".join(AUTHORS),
     author_email='alexander.belopolsky@gmail.com',
     maintainer=", ".join(AUTHORS),
@@ -32,6 +32,7 @@ setup(
     long_description_content_type="text/markdown",
     packages=['pytest_leaks'],
     install_requires=['pytest>=3'],
+    setup_requires=["setuptools-scm", "setuptools>=40.0"],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     classifiers=[
         'Development Status :: 1 - Planning',


### PR DESCRIPTION
This is how pytest itself does it, fully based on git tags, so could make
sense to follow suit.