### PR TITLE
MAINT: fix version import

### DIFF
--- a/pytest_leaks/__init__.py
+++ b/pytest_leaks/__init__.py
@@ -1,5 +1,5 @@
 try:
     # _version.py is written by setuptools-scm
-    from ._version import __version__
+    from ._version import version as __version__
 except ImportError:
     __version__ = "unknown"


### PR DESCRIPTION
[Default template](https://github.com/pypa/setuptools_scm/blob/v3.3.3/src/setuptools_scm/__init__.py#L15) of setuptools-scm  uses `version`, not `__version__`. 


Improper import causes version to be always unknown.