### PR TITLE
BUG: clear pytest captured output in test cycle

### DIFF
--- a/pytest_leaks/plugin.py
+++ b/pytest_leaks/plugin.py
@@ -137,7 +137,11 @@ class LeakChecker(object):
                 item.funcargs = None
 
             if doctest_original_globs is not None:
+                # Restore doctest environment
                 item.dtest.globs.update(doctest_original_globs)
+
+            # Clear pytest captured output etc., if any
+            item._report_sections = []
 
         if hasattr(self.runner.CallInfo, 'from_call'):
             # pytest >= 4

--- a/tests/test_leaks.py
+++ b/tests/test_leaks.py
@@ -234,3 +234,34 @@ def test_fixture_setup_teardown(testdir):
     result.stdout.fnmatch_lines([
         "*::test_sth PASSED*"
     ])
+
+
+def test_output_capture(testdir):
+    test_code = """
+    def test_output_capture_default():
+        print('Hello there.')
+
+    def test_output_capture_capsys(capsys):
+        print('Hello here.')
+        out, err = capsys.readouterr()
+        assert out.strip() == 'Hello here.'
+        print('Hello where.')
+
+    def test_output_capture_capfd(capfd):
+        print('Hello their.')
+        out, err = capfd.readouterr()
+        assert out.strip() == 'Hello their.'
+        print('Hello these.')
+    """
+
+    testdir.makepyfile(test_code)
+
+    result = testdir.runpytest_subprocess(
+        '-R', ':', '-v'
+    )
+
+    result.stdout.fnmatch_lines([
+        "*::test_output_capture_default PASSED*",
+        "*::test_output_capture_capsys PASSED*",
+        "*::test_output_capture_capfd PASSED*",
+    ])


### PR DESCRIPTION
We monkeypatch the Item object, as the recorded output apparently cannot
be flushed otherwise.

Closes gh-24