### PR TITLE
Implement pytest.mark.no_leak_check

### DIFF
--- a/pytest_leaks/plugin.py
+++ b/pytest_leaks/plugin.py
@@ -70,6 +70,10 @@ def pytest_configure(config):
         checker = LeakChecker(config)
         config.pluginmanager.register(checker, 'leaks_checker')
 
+    config.addinivalue_line(
+        "markers",
+        "no_leak_check: don't run pytest-leaks on this test")
+
 
 @pytest.fixture
 def leaks_checker(request):
@@ -109,6 +113,11 @@ class LeakChecker(object):
 
     @pytest.hookimpl(tryfirst=True)
     def pytest_runtest_protocol(self, item, nextitem):
+        marker = item.get_closest_marker('no_leak_check')
+        if marker:
+            # Don't run leak check
+            return
+
         when = ["setup"]
         hook = item.ihook
 

--- a/tests/test_leaks.py
+++ b/tests/test_leaks.py
@@ -265,3 +265,29 @@ def test_output_capture(testdir):
         "*::test_output_capture_capsys PASSED*",
         "*::test_output_capture_capfd PASSED*",
     ])
+
+
+def test_marker_skip_leaks(testdir):
+    test_code = """
+    import pytest
+
+    garbage = []
+
+    @pytest.mark.no_leak_check
+    def test_leaking_skip():
+        garbage.append(None)
+
+    def test_leaking_noskip():
+        garbage.append(None)
+    """
+
+    testdir.makepyfile(test_code)
+
+    result = testdir.runpytest_subprocess(
+        '-R', ':', '-v'
+    )
+
+    result.stdout.fnmatch_lines([
+        "*::test_leaking_skip PASSED*",
+        "*::test_leaking_noskip LEAKED*",
+    ])


### PR DESCRIPTION
Implement pytest marker `no_leak_check` for skipping leak checks for specific tests only.

Closes: #26